### PR TITLE
[CSP-1605] New eslintrc.js and affected files fixed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
 	env: {
 		node: true,
+		es6: true,
 	},
 	globals: {
 		_: true,
@@ -8,17 +9,19 @@ module.exports = {
 		mout: true,
 		falafel: true,
 	},
-	extends: [
-		'eslint:recommended',
-		'plugin:prettier/recommended',
-		'plugin:jest/recommended',
+	plugins: [
+		"jest"
 	],
+	extends: ['eslint:recommended', 'plugin:prettier/recommended', 'plugin:jest/recommended'],
 	parserOptions: {
 		ecmaVersion: 2018,
 		sourceType: 'module',
 	},
 	rules: {
 		'prettier/prettier': 'error',
-		'no-console': 1,
-	},
-};
+		"no-console": 1,
+		'no-unused-vars': ["error", { "args": "none" }],
+		"prefer-template": 'error',
+		"curly": 'error'
+	}
+}

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -245,7 +245,7 @@ module.exports = class extends generators {
 
 		this.fs.copyTpl(
 			this.templatePath(`${templateFolder}/connector.js`),
-			this.destinationPath('connectors/' + this.name + '/connector.js'),
+			this.destinationPath(`connectors/${this.name}/connector.js`),
 			{
 				title: this.title,
 				name: this.name,

--- a/generators/app/templates/connector/connector.js
+++ b/generators/app/templates/connector/connector.js
@@ -22,6 +22,7 @@ module.exports = {
 	// Icon of the connector.
 	icon: {
 		type: 'url',
-		value: '//s3.amazonaws.com/images.tray.io/artisan/icons/<%= name %>.png',
+		value:
+			'//s3.amazonaws.com/images.tray.io/artisan/icons/<%= name %>.png',
 	},
 };

--- a/generators/app/templates/jest.config.js
+++ b/generators/app/templates/jest.config.js
@@ -22,5 +22,5 @@ module.exports = {
 	verbose: true,
 
 	// Ignores coverage information for test files
-	coveragePathIgnorePatterns: [, '/tests/']
+	coveragePathIgnorePatterns: ['/tests/'],
 };

--- a/generators/app/templates/main.js
+++ b/generators/app/templates/main.js
@@ -1,7 +1,7 @@
 var Falafel = require('@trayio/falafel');
 // Set up the lambda function by wrapping the current directory
 var apptalk = new Falafel().wrap({
-	directory: __dirname + '/',
+	directory: `${__dirname}/`,
 });
 
 // Export the apptalk lambda function

--- a/generators/app/templates/tests/setup.js
+++ b/generators/app/templates/tests/setup.js
@@ -1,4 +1,4 @@
 require('dotenv').config(); //Inject environment variables
 const Falafel = require('@trayio/falafel');
 
-new Falafel().wrap({ directory: __dirname + '/../', test: true });
+new Falafel().wrap({ directory: `${__dirname}/../`, test: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-trayio-nodejs-connector",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-trayio-nodejs-connector",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"description": "Yeoman generator for creating Node.js connectors for the tray.io platform",
 	"files": [
 		"generators/app"


### PR DESCRIPTION
Fixes [CSP-1605](https://trayio.atlassian.net/browse/CSP-1605).

This PR:
* updates `.eslintrc.js` to be the same as in /connectors
* replaces files affected by `eslint ./ --fix` so that they are the fixed versions

New `.eslintrc.js` was recently merged with the `/connectors` repo but new rules have not been applied here, so the skeletons produced by this generator contain errors that `eslint` will pick up on, and if we do not `--fix` them, the `eslint` check on connector PRs fail.

Issues #18, #19 fixed by this.  

`jest.config.js` will have been fixed by #17 so is excluded from from this PR. 